### PR TITLE
repair Asciidoc link to Super-Linter results

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -3,7 +3,7 @@ gunstage
 
 🔫 `git unstage` as a service
 
-https://github.com/LucasLarson/gunstage/actions?query=workflow:"Super-Linter"[image:https://img.shields.io/github/workflow/status/LucasLarson/gunstage/Super-Linter?logo=GitHub&label=Super-Linter[GitHub Super-Linter]]
+https://github.com/LucasLarson/gunstage/actions?query=workflow:Super-Linter[image:https://img.shields.io/github/workflow/status/LucasLarson/gunstage/Super-Linter?logo=GitHub&label=Super-Linter[GitHub Super-Linter]]
 https://github.com/LucasLarson/gunstage/blob/main/license.md[image:https://img.shields.io/badge/license-GPLP-blue[GPLP,title="GNU General Public License for Pedants"]]
 
 What


### PR DESCRIPTION
Unescaped and unnecessary double quotation marks appear to have truncated the link. This PR #6 repairs that.