### PR TITLE
repair cross-OS compatibility (fix #27)

### DIFF
--- a/gunstage.plugin.zsh
+++ b/gunstage.plugin.zsh
@@ -30,7 +30,7 @@ gunstage () {( # 🔫 `git unstage` as a service
       if (
         printf 'minimum version 2.23.0\n'
         git --version
-      ) | sort --version-sort --key=3 | tail -n -1 | grep --quiet git; then
+      ) | sort --version-sort --key=3 | tail -n -1 | grep -q git; then
 
         # we’re on modern Git
         gunstage="git restore --staged --progress"


### PR DESCRIPTION
✅ replace `grep --quiet` with `grep -q` (BusyBox’s grep doesn’t support `--quiet`; #27)
✅ partially undo LucasLarson/gunstage@245c3fc