### PR TITLE
replace deprecated `actions/setup-ruby` with `ruby/setup-ruby` (fix #62)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1.1.3
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.x
       - uses: actions/cache@v2.1.5


### PR DESCRIPTION
fix #62 which notes that `actions/setup-ruby` is deprecated;<sup>1</sup> `ruby/setup-ruby`<sup>2</sup> is the recommended replacement.

---
1. https://github.com/actions/setup-ruby/commit/e932e7af67fc4a8fc77bd86b744acd4e42fe3543#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9
2. https://github.com/ruby/setup-ruby