### PR TITLE
repair Git content in changelog generator

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,14 +28,14 @@ jobs:
           gem install github_changelog_generator
           github_changelog_generator \
           -u ${{ github.repository_owner }} \
-          -p gunstage \
+          -p "$(git rev-parse --show-toplevel | xargs basename)" \
           -t ${{ secrets.GITHUB_TOKEN }} \
           --exclude-labels duplicate,question,invalid,wontfix,nodoc \
           --output changelog.md
       - name: Commit files
         run: |
-          git config --local user.email "action@github.com" && \
-          git config --local user.name "GitHub Actions" && \
+          git config --local user.email "actions@github.com" && \
+          git config --local user.name "GitHub" && \
           git add --verbose --all && \
           git commit --verbose --message '[ci skip] Updating changelog'
       - name: Push changes


### PR DESCRIPTION
- [x] use repository-agnostic `"$(git rev-parse --show-toplevel | xargs basename)"` to generate the string “`gunstage`”
- [x] use the correct dummy email address `actions@github.com`
- [x] use GitHub for committer name