### PR TITLE
prevent the creation of a `$PATH` that begins with a colon `:`

### DIFF
--- a/gunstage.plugin.zsh
+++ b/gunstage.plugin.zsh
@@ -19,7 +19,9 @@
 
 # enable `git unstage` in addition to `gunstage`
 # by adding `bin` directory to `PATH`
-PATH=${PATH}:$(dirname "$0")/bin
+# without adding an initial colon `:` to `PATH`
+# https://unix.stackexchange.com/a/415028
+PATH=${PATH:+${PATH}:}$(dirname "$0")/bin
 export PATH
 
 # keep backwards compatibility


### PR DESCRIPTION
if `$PATH` is unset, we want to avoid creating `$PATH` with an initial `:` (colon) ([via](https://unix.stackexchange.com/a/415028))