### PR TITLE
exclude autogenerated changelog from DeepSource analysis

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,5 +1,7 @@
 version = 1
 
+exclude_patterns = ["**/*changelog.md"]
+
 [[analyzers]]
 name = "python"
 enabled = true


### PR DESCRIPTION
Matching “[g]lob patterns of files that shouldn’t be analyzed, such as auto[]generated files” ([source](https://archive.today/2021.05.14-154625/https://static.deepsource.io/CACHE/js/output.82f9da041121.js#selection-9.23684-9.23763))