### PR TITLE
disable DeepSource’s Prettier rather than ignoring the changelog

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,7 +1,5 @@
 version = 1
 
-exclude_patterns = ["**/*changelog.md"]
-
 [[analyzers]]
 name = "python"
 enabled = true
@@ -78,7 +76,7 @@ enabled = true
 
 [[transformers]]
 name = "prettier"
-enabled = true
+enabled = false
 
 [[transformers]]
 name = "black"


### PR DESCRIPTION
Prettier is causing `.md` and `.json` file problems

- changelog.md is generated with [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator)
- renovate.json is formatted with [jsonlint-newline-fork](https://github.com/kevcenteno/jsonlint)