### PR TITLE
repair linkrot for GitHub URL parser (fix #91)

### DIFF
--- a/bin/git-unstage
+++ b/bin/git-unstage
@@ -27,7 +27,7 @@ gunstage() {
     # otherwise use `.` for everything in the current directory and below
     for file in "${@:-.}"; do
 
-      # https://github.com/gggritso/gggritso.com/commit/a07b620
+      # https://github.com/gggritso/site/commit/a07b620
       git reset --quiet HEAD -- "${file}"
 
       # perform a `git status` only if the loop was successful


### PR DESCRIPTION
GitHub’s URL parsing produces unexpected results.

When a repository is renamed, for example from `gggritso.com` to `site`, old links to the repository seamlessly redirect to the new repository’s address. But there are unexpected exceptions when linking to commits,[^1] but not when linking to files.

| working | note | URL |
| - | - | - |
| no | old name, short hash | `https://github.com/gggritso/gggritso.com/commit/a07b620` |
| yes | new name, short hash | `https://github.com/gggritso/site/commit/a07b620`[^2] |
| no | old name, long hash | `https://github.com/gggritso/gggritso.com/commit/a07b620905a6c4d1f1f6dd3738c0e031cb2da7a9` |
| yes | new name, long hash | `https://github.com/gggritso/site/commit/a07b620905a6c4d1f1f6dd3738c0e031cb2da7a9` |
| yes | old name, short hash, specific file | `https://github.com/gggritso/gggritso.com/commit/a07b620/_posts/2015-08-23-human-git-aliases.md` |

And extraordinarily, these links to the _old_ repository name with short commit hashes to a specific file _do_ work:
| working | type | old name, short hash, specific file |
| - | - | - |
| yes | commit | `https://github.com/gggritso/gggritso.com/commit/a07b620/_posts/2015-08-23-human-git-aliases.md` |
| yes | blob | `https://github.com/gggritso/gggritso.com/blob/a07b620/_posts/2015-08-23-human-git-aliases.md` |
| yes | tree | `https://github.com/gggritso/gggritso.com/tree/a07b620/_posts/2015-08-23-human-git-aliases.md` |

---

[^1]: For example, https://github.com/LucasLarson/gunstage/issues/91#issue-1007518701.
[^2]: This is the URL used in this pull request which, with as little change as possible, will fix #91.