### PR TITLE
add functionality to unstage everything with `gunstage --all` (fix #89)

### DIFF
--- a/bin/git-unstage
+++ b/bin/git-unstage
@@ -23,15 +23,27 @@ gunstage() {
   # https://stackoverflow.com/a/53809163
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 
-    # run the same command against each argument, if any
-    # otherwise use `.` for everything in the current directory and below
-    for file in "${@:-.}"; do
+    case $1 in
+    -A | --all)
 
-      # https://github.com/gggritso/site/commit/a07b620
-      git reset --quiet HEAD -- "${file}"
+      # unstage everything
+      git reset --quiet HEAD -- "$(git rev-parse --show-toplevel)"
+      git status
+      ;;
 
-      # perform a `git status` only if the loop was successful
-    done && git status
+    *)
+      # run the same command against each argument, if any
+      # otherwise use `.` for everything in the current directory and below
+      for file in "${@:-.}"; do
+
+        # https://github.com/gggritso/site/commit/a07b620
+        git reset --quiet HEAD -- "${file}"
+
+        # perform a `git status` only if the loop was successful
+      done && git status
+
+      ;;
+    esac
 
   else
     # we’re not in a Git repository

--- a/readme.adoc
+++ b/readme.adoc
@@ -19,11 +19,13 @@ This is a command-line shell plugin for undoing `git add`. Too many
 staged&nbsp;files? Can’t remember if it’s `git reset HEAD` or
 `git restore --staged --`? Just remember `gunstage` or `git unstage`.
 
-If you don’t want to unstage everything, more granular control
-is&nbsp;available. `gunstage` works exactly as you would expect it to as it
-performs the opposite of `git add`. You can unstage directories and
-specific files in as few commands as you’d like:
+`gunstage` works exactly as you would expect it to as it performs the opposite
+of `git add`. You can unstage directories and specific files in as few
+commands as you’d&nbsp;like:
 `gunstage file1.txt file2.txt directory/`.
+
+Want to unstage everything? Well that’s as easy as
+`gunstage --all` or `gunstage -A`.
 
 Why
 ~~~


### PR DESCRIPTION
this functionality is provided with any of the four commands which resolve #89:
- `git unstage --all`
- `git unstage -A`
- `gunstage --all`
- `gunstage -A`