### PR TITLE
repair Markdown syntax (fix #95)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to . . . .
 2. Click on . . . .
 3. Scroll down to . . . .
@@ -24,11 +25,13 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
+
 - OS: [like iOS]
 - Browser: [like Chrome, Safari]
 - Version: [like 22]
 
 **Smartphone (please complete the following information):**
+
 - Device: [like iPhone 6]
 - OS: [like iOS 8.1]
 - Browser: [like stock browser, Safari]

--- a/.github/code_of_conduct.md
+++ b/.github/code_of_conduct.md
@@ -14,17 +14,18 @@ diverse, inclusive, and healthy&nbsp;community.
 
 <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
-- [Our Pledge](#our-pledge)
-- [Our Standards](#our-standards)
-- [Enforcement Responsibilities](#enforcement-responsibilities)
-- [Scope](#scope)
-- [Enforcement](#enforcement)
-- [Enforcement Guidelines](#enforcement-guidelines)
-  1. [Correction](#1-correction)
-  1. [Warning](#2-warning)
-  1. [Temporary Ban](#3-temporary-ban)
-  1. [Permanent Ban](#4-permanent-ban)
-- [Attribution](#attribution)
+- [Contributor Covenant Code of Conduct for Pedants](#contributor-covenant-code-of-conduct-for-pedants)
+  - [Our Pledge](#our-pledge)
+  - [Our Standards](#our-standards)
+  - [Enforcement Responsibilities](#enforcement-responsibilities)
+  - [Scope](#scope)
+  - [Enforcement](#enforcement)
+  - [Enforcement Guidelines](#enforcement-guidelines)
+    1. [Correction](#1-correction)
+    1. [Warning](#2-warning)
+    1. [Temporary Ban](#3-temporary-ban)
+    1. [Permanent Ban](#4-permanent-ban)
+  - [Attribution](#attribution)
 
 <!-- /TOC -->
 
@@ -33,24 +34,24 @@ diverse, inclusive, and healthy&nbsp;community.
 Examples of behavior that contributes to a positive environment for our
 community&nbsp;include:
 
-* Demonstrating empathy and kindness toward other&nbsp;people
-* Being respectful of differing opinions, viewpoints, and&nbsp;experiences
-* Giving and gracefully accepting constructive&nbsp;feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other&nbsp;people
+- Being respectful of differing opinions, viewpoints, and&nbsp;experiences
+- Giving and gracefully accepting constructive&nbsp;feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the&nbsp;experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall&nbsp;community
 
 Examples of unacceptable behavior&nbsp;include:
 
-* The use of sexualized language or imagery, and sexual attention or advances
+- The use of sexualized language or imagery, and sexual attention or advances
   of any&nbsp;kind
-* Trolling, insulting or derogatory comments, and personal or
+- Trolling, insulting or derogatory comments, and personal or
   political&nbsp;attacks
-* Public or private&nbsp;harassment
-* Publishing others’ private information, such as a physical or email address,
+- Public or private&nbsp;harassment
+- Publishing others’ private information, such as a physical or email address,
   without their explicit&nbsp;permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional&nbsp;setting
 
 ## Enforcement Responsibilities

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@
 <!-- Put an `x` in all the boxes [x] that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Breaking change (fix or feature that would change existing functionality)
 
 ### Checklist
 <!-- Put an `x` in only the boxes [x] that apply. -->


### PR DESCRIPTION
The Markdown syntax in these files isn’t to specification.
- https://github.com/LucasLarson/gunstage/blob/abfd1120a6e47ec5c902d31c5710cfc4d381083d/.github/ISSUE_TEMPLATE/bug_report.md
- https://github.com/LucasLarson/gunstage/blob/0a75bb931aea19e8fe91ccd7e72eeb6de2c9dd97/.github/code_of_conduct.md

This request will fix #95.