### PR TITLE
add `markdownlint` to changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,17 +23,23 @@ jobs:
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gem-
-      - name: Create local changes
+      - name: Install `github_changelog_generator`
         run: |
           command gem install github_changelog_generator
+      - name: Install `markdownlint`
+        run: |
+          command npm install markdownlint
+          command npm install markdownlint-cli
+      - name: Create local changes
+        run: |
           command github_changelog_generator \
             --user "$(
               command git config --get-regexp -- 'remote.*url' |
-                command sed -E -e 's/(git@|https:..)//' |
-                command sed -e 's/:/\//' |
-                command sed -e 's/\.git$//' |
+                command sed -E -e 's/(git@|https:\/\/)//' \
+                  -e 's/:/\//' \
+                  -e 's/\.git$//' |
                 command awk -F '/' '{print $2}' |
-                LC_ALL='C' command sort -u
+                command head -n 1
             )" \
             --project "$(
               command git remote get-url "$(
@@ -41,22 +47,53 @@ jobs:
                   command git config --get --worktree checkout.defaultRemote ||
                     command git config --get --local checkout.defaultRemote ||
                     command git config --get --system checkout.defaultRemote ||
-                    command git config --get --global checkout.defaultRemote ||
-                    printf "origin\n"
-                } 2>/dev/null
+                    command git config --get --global checkout.defaultRemote
+                } 2>/dev/null ||
+                  printf 'origin'
               )" |
-                command tr -d "[:space:]" |
+                command tr -d '[:space:]' |
                 command xargs basename |
-                command sed -e "s|.git$||"
+                command sed -e 's/\.git$//'
             )" \
             --token ${{ secrets.GITHUB_TOKEN || secrets.PAT }} \
-            --exclude-labels duplicate,question,invalid,wontfix,nodoc \
-            --output changelog.md
+            --exclude-labels 'duplicate,question,invalid,wontfix,nodoc' \
+            --output "$(
+              command find -- . \
+                -maxdepth 1 \
+                -type f \
+                -name '*.m*d*' \
+                '(' \
+                -name 'change*log*' -o \
+                -name 'CHANGE*LOG*' \
+                ')' |
+                command sed -e 's/^.\///'
+            )"
+      - name: Lint changelog
+        run: |
+          command find -- . \
+            -maxdepth 1 \
+            -type f \
+            -name '*.m*d*' \
+            '(' \
+            -name 'change*log*' -o \
+            -name 'CHANGE*LOG*' \
+            ')' \
+            -print \
+            -exec npx markdownlint --fix -- '{}' ';'
       - name: Commit files
         run: |
           command git config -- user.email 'actions@github.com'
           command git config -- user.name 'GitHub'
-          command git add --verbose --all
+          command find -- . \
+            -maxdepth 1 \
+            -type f \
+            -name '*.m*d*' \
+            '(' \
+            -name 'change*log*' -o \
+            -name 'CHANGE*LOG*' \
+            ')' \
+            -print \
+            -exec git add --verbose -- '{}' ';'
           command git commit --verbose \
             --message='update changelog' ||
             exit 0


### PR DESCRIPTION
[github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) inserts overabundant vertical space,[^1] about which [GitHub Super‑Linter](https://github.com/github/super-linter)’s instance of [markdownlint](https://github.com/DavidAnson/markdownlint) complains. This request to merge will fix #112.

[^1]: https://github.com/LucasLarson/gunstage/blob/a420181539d38ea873f489f24176047c19aee48d/changelog.md#L170-L174