### PR TITLE
add mechanism to return version number (#117)

### DIFF
--- a/bin/git-unstage
+++ b/bin/git-unstage
@@ -34,6 +34,14 @@ gunstage() {
       command git status
       ;;
 
+    -V | --version)
+      command git --git-dir="$(
+        command -v -- git-unstage |
+          command sed -e 's/\(.*\)bin\/git-unstage/\1.git/'
+      )" describe --tags
+      exit 0
+      ;;
+
     *)
       # run the same command against each argument, if any
       # otherwise use `.` for everything in the current directory and below


### PR DESCRIPTION
Learn to recognize `-V` and `--version` arguments and fix #117:
```sh
gunstage --version
```

returns
> ```sh
> v1.8.2-24-gc4b3caba80
> ```