### PR TITLE
add fig installation link

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -95,8 +95,9 @@ Installation
 ^^^^^^^^^^^^
 `gunstage` can be
 https://gist.github.com/06009589d7887617e061481e22cf5a4a[installed as a
-plugin^] or you can just clone this repository, run the following command, and
-then restart your terminal:
+plugin^], https://fig.io/plugins/other/gunstage_LucasLarson[installed
+using Fig^], or you can just clone this repository, run the following
+command, and then restart your terminal:
 [source,zsh]
 $ printf '%s\n' '. /path/to/gunstage.plugin.zsh' \
   >>"${HOME-}"'/.'"${SHELL##*[-./]}"'rc'


### PR DESCRIPTION
gunstage is [available on Fig](https://fig.io/plugins/other/gunstage_LucasLarson). This pull request adds a link to it and fixes #123 (and is related to #110 and #122).