### PR TITLE
ensure `root` `$HOME` expands to `/`

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -100,7 +100,7 @@ using Fig^], or you can just clone this repository, run the following
 command, and then restart your terminal:
 [source,zsh]
 $ printf '%s\n' '. /path/to/gunstage.plugin.zsh' \
-  >>"${HOME-}"'/.'"${SHELL##*[-./]}"'rc'
+  >>"${HOME%/}"'/.'"${SHELL##*[-./]}"'rc'
 
 Requirements
 ~~~~~~~~~~~~


### PR DESCRIPTION
ensure that when `root` installs the plugin, the reference in their run-command file is to a path without multiple contiguous `/` instances

https://mywiki.wooledge.org/BashPitfalls?rev=565#line-1-81
https://github.com/LucasLarson/dotfiles/commit/98cf52dcec
