### PR TITLE
feat: optimize `$PATH` relationship

### DIFF
--- a/gunstage.plugin.zsh
+++ b/gunstage.plugin.zsh
@@ -21,7 +21,7 @@
 # by adding `bin` directory to `PATH`
 # without adding an initial colon `:` to `PATH`
 # https://unix.stackexchange.com/a/415028
-PATH="${PATH:+${PATH}:}$(command dirname "$0")/bin"
+PATH="${PATH:+${PATH-}:}$(command dirname "$0")/bin"
 export PATH
 
 # keep backwards compatibility

--- a/gunstage.plugin.zsh
+++ b/gunstage.plugin.zsh
@@ -19,8 +19,7 @@
 
 # enable `git unstage` in addition to `gunstage`
 # by adding `bin` directory to `PATH`
-PATH="$(command dirname "$0")/bin${PATH:+:${PATH-}}"
-export PATH
+export PATH="${0%/*}"'/bin'"${PATH:+:${PATH-}}"
 
 # keep backwards compatibility
 alias gunstage='git-unstage'

--- a/gunstage.plugin.zsh
+++ b/gunstage.plugin.zsh
@@ -19,9 +19,7 @@
 
 # enable `git unstage` in addition to `gunstage`
 # by adding `bin` directory to `PATH`
-# without adding an initial colon `:` to `PATH`
-# https://unix.stackexchange.com/a/415028
-PATH="${PATH:+${PATH-}:}$(command dirname "$0")/bin"
+PATH="$(command dirname "$0")/bin${PATH:+:${PATH-}}"
 export PATH
 
 # keep backwards compatibility


### PR DESCRIPTION
- [x] avoid unbound-variable error ([`9a61ec5b6c`](https://github.com/LucasLarson/gunstage/commit/9a61ec5b6c))
- [x] prepend gunstage to `$PATH` ([`e384a1b1f5`](https://github.com/LucasLarson/gunstage/commit/e384a1b1f5))
- [x] remove slow `dirname` call ([SC2155](https://github.com/koalaman/shellcheck/wiki/SC2155)) ([`b862c8ba23`](https://github.com/LucasLarson/gunstage/commit/b862c8ba23))