### PR TITLE
feat: skip Biome formatting

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -50,6 +50,7 @@ jobs:
         uses: super-linter/super-linter@v8
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_BIOME_FORMAT: false
           DEFAULT_BRANCH: main
           # Super-Linter requires this variable even if it is unset
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -47,7 +47,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter@v8
+        uses: super-linter/super-linter@v8 # zizmor: ignore[unpinned-uses]
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BIOME_FORMAT: false


### PR DESCRIPTION
prefer `prettier`

## Summary by Sourcery

CI:
- set VALIDATE_BIOME_FORMAT to false to skip Biome formatting validation